### PR TITLE
feat: Fix for recalculate component height after resize

### DIFF
--- a/src/lib/headroom.component.ts
+++ b/src/lib/headroom.component.ts
@@ -117,7 +117,7 @@ export class HeadroomComponent implements OnInit, AfterContentInit {
   resizeTicking = false;
   state = 'unfixed';
   translateY = '0px';
-  height: number | 'auto';
+  height: number;
   scrollTicking = false;
   /**
    * provide a custom 'parent' element for scroll events.
@@ -163,7 +163,7 @@ export class HeadroomComponent implements OnInit, AfterContentInit {
     this.wrapperHeight = this.height ? this.height : null;
   }
   setHeightOffset() {
-    this.height = 'auto';
+    this.height = null;
     setTimeout(() => {
       this.height = this.inner.nativeElement.offsetHeight;
       this.resizeTicking = false;

--- a/src/lib/headroom.component.ts
+++ b/src/lib/headroom.component.ts
@@ -117,7 +117,7 @@ export class HeadroomComponent implements OnInit, AfterContentInit {
   resizeTicking = false;
   state = 'unfixed';
   translateY = '0px';
-  height: number;
+  height: number | 'auto';
   scrollTicking = false;
   /**
    * provide a custom 'parent' element for scroll events.

--- a/src/lib/headroom.component.ts
+++ b/src/lib/headroom.component.ts
@@ -163,8 +163,11 @@ export class HeadroomComponent implements OnInit, AfterContentInit {
     this.wrapperHeight = this.height ? this.height : null;
   }
   setHeightOffset() {
-    this.height = this.inner.nativeElement.offsetHeight;
-    this.resizeTicking = false;
+    this.height = 'auto';
+    setTimeout(() => {
+      this.height = this.inner.nativeElement.offsetHeight;
+      this.resizeTicking = false;
+    },0);
   }
   getScrollY() {
     if (this.getParent().pageYOffset !== undefined) {

--- a/src/lib/headroom.component.ts
+++ b/src/lib/headroom.component.ts
@@ -167,7 +167,7 @@ export class HeadroomComponent implements OnInit, AfterContentInit {
     setTimeout(() => {
       this.height = this.inner.nativeElement.offsetHeight;
       this.resizeTicking = false;
-    },0);
+    }, 0);
   }
   getScrollY() {
     if (this.getParent().pageYOffset !== undefined) {


### PR DESCRIPTION
Now when you try to change the size of the component the height of the component is set as inline style,
which makes the recheck of the height not accurate because the height is in the style. you need to remove it first (set to 'auto') and recalc the element height.